### PR TITLE
feat: migrate media fields from entity_browser to media_library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "Open Y focal point implementation and enchancements.",
   "type": "drupal-module",
   "require": {
-    "ymcatwincities/openy": "*",
     "drupal/focal_point": "1.5 || ^2.0"
   },
   "license": "GPL-2.0+",

--- a/openy_focal_point.module
+++ b/openy_focal_point.module
@@ -1,6 +1,9 @@
 <?php
 
-use Drupal\Core\Form\FormStateInterface;
+/**
+ * @file
+ * OpenY Focal Point module file.
+ */
 
 /**
  * Implements hook_theme().
@@ -12,22 +15,5 @@ function openy_focal_point_theme($existing, $type, $theme, $path) {
         'data' => [],
       ],
     ],
-  ];
-}
-
-/**
- * Implements hook_form_FORM_ID_alter() for media_image_edit_form.
- */
-function openy_focal_point_form_media_image_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $paragraph_type = \Drupal::request()->query->get('paragraph_type');
-  $field_name = \Drupal::request()->query->get('field_name');
-
-  if (!$paragraph_type || !$field_name) {
-    return;
-  }
-
-  $form['actions']['submit']['#ajax']['options']['query'] += [
-    'paragraph_type' => $paragraph_type,
-    'field_name' => $field_name,
   ];
 }


### PR DESCRIPTION
## Summary

ITCR-1084: Deprecate entity_browser in favor of core media_library widget.

### Changes
- Add update hook to change media field widgets from entity_browser_entity_reference to media_library_widget
- Update config/optional form displays to use media_library_widget
- Remove entity_browser dependency from info.yml

### Why
This is part of the YUSAOpenY initiative to remove deprecated entity_browser and media_directories modules in favor of Drupal core Media Library.

### Test plan
1. Run drush updb to execute update hooks
2. Edit content with media fields
3. Verify media fields use Media Library widget (not Entity Browser)
4. Check browser console for no JavaScript errors

Related: https://github.com/YCloudYUSA/yusaopeny_docs/issues/138
