### PR TITLE
feat: allow SVG uploads when svg is listed in field extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "Open Y focal point implementation and enchancements.",
   "type": "drupal-module",
   "require": {
-    "drupal/focal_point": "1.5 || ^2.0"
+    "drupal/focal_point": "1.5 || ^2.0",
+    "drupal/svg_image": "^3.2"
   },
   "license": "GPL-2.0+",
   "minimum-stability": "dev"

--- a/openy_focal_point.info.yml
+++ b/openy_focal_point.info.yml
@@ -5,3 +5,4 @@ package: YMCA Website Services
 core_version_requirement: ^10 || ^11
 dependencies:
   - image_widget_crop:image_widget_crop
+  - svg_image:svg_image

--- a/src/Plugin/Field/FieldWidget/OpenYFocalPointImageWidget.php
+++ b/src/Plugin/Field/FieldWidget/OpenYFocalPointImageWidget.php
@@ -3,6 +3,7 @@
 namespace Drupal\openy_focal_point\Plugin\Field\FieldWidget;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\focal_point\Plugin\Field\FieldWidget\FocalPointImageWidget;
 use Drupal\Core\Url;
@@ -25,6 +26,34 @@ use Drupal\Core\Url;
  * )
  */
 class OpenYFocalPointImageWidget extends FocalPointImageWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    $field_extensions = $this->getFieldSetting('file_extensions');
+    if (!in_array('svg', explode(' ', $field_extensions ?? ''))) {
+      return $element;
+    }
+
+    // ImageWidget::formElement() intersects file_extensions with the image
+    // toolkit's supported extensions. GD does not support SVG, so svg gets
+    // stripped out even when it is listed in the field settings. Re-add it and
+    // remove the FileIsImage validator so SVG files can be uploaded.
+    unset($element['#upload_validators']['FileIsImage']);
+
+    if (isset($element['#upload_validators']['FileExtension']['extensions'])) {
+      $current = explode(' ', $element['#upload_validators']['FileExtension']['extensions']);
+      if (!in_array('svg', $current)) {
+        $current[] = 'svg';
+        $element['#upload_validators']['FileExtension']['extensions'] = implode(' ', $current);
+      }
+    }
+
+    return $element;
+  }
 
   /**
    * Create the preview link form element.


### PR DESCRIPTION
## Problem

`ImageWidget::formElement()` intersects the field's `file_extensions` setting with the image toolkit's supported extensions (`getSupportedExtensions()`). The GD toolkit does not support SVG, so `svg` gets stripped out even when it is explicitly listed in the field settings — causing the `FileExtension` validator to reject SVG uploads with:

> The selected file example.svg cannot be uploaded. Only files with the following extensions are allowed: png, gif, jpg, jpeg.

## Solution

Override `formElement()` in `OpenYFocalPointImageWidget` to:

1. Re-add `svg` to the `FileExtension` validator extensions
2. Remove the `FileIsImage` validator (which rejects SVG because GD cannot process it as a raster image)

Both changes apply **only** when `svg` is explicitly listed in the field's `file_extensions` setting, so existing behavior is unchanged for fields that do not allow SVG.

This mirrors the approach used by the `svg_image` module for the core `image_image` widget.

## Testing

1. Add `svg` to allowed extensions on an image field (e.g. `media.image.field_media_image`)
2. Go to `/media/add/image`
3. Upload an SVG file — should succeed without errors